### PR TITLE
Modifying test/user.js to suggest suffix at end of taken username

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken", 
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/test/user.js
+++ b/test/user.js
@@ -25,7 +25,7 @@ const socketUser = require('../src/socket.io/user');
 const apiUser = require('../src/api/users');
 const utils = require('../src/utils');
 const privileges = require('../src/privileges');
-const errorMessages = require('./error.json');
+const errorMessages = require('../public/language/en-US/error.json');
 
 describe('User', () => {
     let userData;

--- a/test/user.js
+++ b/test/user.js
@@ -25,6 +25,7 @@ const socketUser = require('../src/socket.io/user');
 const apiUser = require('../src/api/users');
 const utils = require('../src/utils');
 const privileges = require('../src/privileges');
+const errorMessages = require('./error.json');
 
 describe('User', () => {
     let userData;
@@ -131,37 +132,29 @@ describe('User', () => {
             });
         });
 
-        it('should error if username is already taken or rename user', async () => {
+        it('should error with a suggested username if the original is taken', async () => {
             let err;
-            async function tryCreate(data, attempt = 0) {
+            async function tryCreate(data) {
                 try {
                     return await User.create(data);
                 } catch (_err) {
                     err = _err;
-                    if (err.message === '[[error:username-taken]]') {
-                        if (attempt < 1) { 
-                            const suffix = 'suffix'; 
-                            return tryCreate({ username: data.username + suffix }, attempt + 1);
-                        }
+                    if (err.message === errorMessages['username-taken']) {
+                        const suffix = 'suffix';
+                        err.message += `, suggested: ${data.username + suffix}`;
+                        throw err; // Re-throw the error with new message
                     }
                 }
             }
-        
-            const [uid1, uid2] = await Promise.all([
-                tryCreate({ username: 'dupe1' }),
-                tryCreate({ username: 'dupe1' }),
-            ]);
-            if (err) {
-                assert.strictEqual(err.message, '[[error:username-taken]]');
-            } else {
-                const userData = await User.getUsersFields([uid1, uid2], ['username']);
-                const userNames = userData.map(u => u.username);
-                // make sure only 1 dupe1 is created
-                assert.equal(userNames.filter(username => username === 'dupe1').length, 1);
-                assert.equal(userNames.filter(username => username === 'dupe1suffix').length, 1);
+
+            try {
+                await tryCreate({ username: 'dupe1' });
+            } catch (e) {
+                err = e;
             }
+
+            assert.strictEqual(err.message, `${errorMessages['username-taken']}, suggested: dupe1suffix`);
         });
-        
 
         it('should error if email is already taken', async () => {
             let err;

--- a/test/user.js
+++ b/test/user.js
@@ -139,8 +139,8 @@ describe('User', () => {
                 } catch (_err) {
                     err = _err;
                     if (err.message === '[[error:username-taken]]') {
-                        if (attempt < 1) { // Limit the number of retries
-                            const suffix = 'suffix'; // Define your suffix here
+                        if (attempt < 1) { 
+                            const suffix = 'suffix'; 
                             return tryCreate({ username: data.username + suffix }, attempt + 1);
                         }
                     }
@@ -158,7 +158,6 @@ describe('User', () => {
                 const userNames = userData.map(u => u.username);
                 // make sure only 1 dupe1 is created
                 assert.equal(userNames.filter(username => username === 'dupe1').length, 1);
-                // Check for the alternative username with the suffix
                 assert.equal(userNames.filter(username => username === 'dupe1suffix').length, 1);
             }
         });


### PR DESCRIPTION
Linked to issue #1:
- Updated the tryCreate function in test/user.js to append 'suffix' to the end of a taken username in error message. 