### PR TITLE
Altered error message to suggest new username when the username already exists

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try \"{username}suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showErrorUsername(username_notify, '[[error:username-taken]]', username);
                 }
 
                 callback();
@@ -173,6 +173,13 @@ define('forum/register', [
         } else {
             showSuccess(password_confirm_notify, successIcon);
         }
+    }
+
+    function showErrorUsername(element, msgKey, username) {
+      translator.translate(msgKey, function (translatedMsg) {
+        var finalMsg = translatedMsg.replace('{username}', username);
+        showError(element, finalMsg);
+      });
     }
 
     function showError(element, msg) {


### PR DESCRIPTION
Resolves #1 

- Changed error message displayed with username is taken
- Suggested a new username that is a concatenation of the old username and "suffix"

![suffix username](https://github.com/CMU-313/NodeBB-S24-R3/assets/115599566/2613c45c-11ef-4ad0-b1b3-0804c57790f3)

