### PR TITLE
Update username taken message in registration to give username suggestion

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, `[[error:username-taken]] Try ${username}${Math.floor(Math.random() * 10000)}`);
+                    showError(username_notify, `[[error:username-taken]]. Try ${username}suffix`);
                 }
 
                 callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]] Try ${username}${Math.floor(Math.random() * 10000)}`);
                 }
 
                 callback();


### PR DESCRIPTION
Fixes #1.
When a username is taken during registration, suggest a new username that is the taken username with 'suffix' appended at the end.