### PR TITLE
Add username suggestions when duplicated

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -36,7 +36,7 @@
 
 	"invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
 
-	"username-taken": "Username taken",
+	"username-taken": "Username taken. Maybe try \"%1suffix\"",
 	"email-taken": "Email taken",
 	"email-nochange": "The email entered is the same as the email already on file.",
 	"email-invited": "Email was already invited",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+	"username-taken": "Username taken. Maybe try \"%1suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/language/sc/error.json
+++ b/public/language/sc/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+	"username-taken": "Username taken. Maybe try \"%1suffix\"",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken, ${username}]]`);
                 }
 
                 callback();

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -273,7 +273,7 @@ module.exports = function (Topics) {
             }
             const exists = await user.existsBySlug(slugify(data.handle));
             if (exists) {
-                throw new Error('[[error:username-taken]]');
+                throw new Error(`[[error:username-taken, ${data.username}]]`);
             }
         }
     }

--- a/src/user/approval.js
+++ b/src/user/approval.js
@@ -39,7 +39,7 @@ module.exports = function (User) {
         await User.isDataValid(userData);
         const usernames = await db.getSortedSetRange('registration:queue', 0, -1);
         if (usernames.includes(userData.username)) {
-            throw new Error('[[error:username-taken]]');
+            throw new Error(`[[error:username-taken, ${userData.username}]]`);
         }
         const keys = usernames.filter(Boolean).map(username => `registration:queue:name:${username}`);
         const data = await db.getObjectsFields(keys, ['email']);

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -24,7 +24,7 @@ module.exports = function (User) {
 
         await User.isDataValid(data);
 
-        await lock(data.username, '[[error:username-taken]]');
+        await lock(data.username, `[[error:username-taken, ${data.username}]]`);
         if (data.email && data.email !== data.username) {
             await lock(data.email, '[[error:email-taken]]');
         }

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -127,7 +127,7 @@ module.exports = function (User) {
         }
         const exists = await User.existsBySlug(userslug);
         if (exists) {
-            throw new Error('[[error:username-taken]]');
+            throw new Error(`[[error:username-taken, ${data.username}]]`);
         }
 
         const { error } = await plugins.hooks.fire('filter:username.check', {

--- a/test/user.js
+++ b/test/user.js
@@ -146,7 +146,7 @@ describe('User', () => {
                 tryCreate({ username: 'dupe1' }),
             ]);
             if (err) {
-                assert.strictEqual(err.message, '[[error:username-taken]]');
+                assert.strictEqual(err.message, `[[error:username-taken, dupe1]]`);
             } else {
                 const userData = await User.getUsersFields([uid1, uid2], ['username']);
                 const userNames = userData.map(u => u.username);
@@ -2060,7 +2060,7 @@ describe('User', () => {
                 gdpr_consent: true,
             }, (err, jar, res, body) => {
                 assert.ifError(err);
-                assert.equal(body, '[[error:username-taken]]');
+                assert.equal(body, `[[error:username-taken, rejectme]]`);
                 done();
             });
         });


### PR DESCRIPTION
When there are duplicated usernames, suggest "usernamesuffix" instead.
Also modified certain tests. Noted that this only works for English version of the website.
<img width="944" alt="Screenshot 2024-02-05 at 11 40 46 AM" src="https://github.com/CMU-313/NodeBB-S24-R3/assets/98172796/4f95d17d-68e1-4376-a171-213cebe3d3ea">
