### PR TITLE
Changed the username error message to add a username suggestion

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]]. Maybe try "${username}suffix".`);
                 }
 
                 callback();


### PR DESCRIPTION
Resolves #1

- Changed error message displayed when the username is taken
- Added a suggestion to add "suffix" to the end of the taken username