### PR TITLE
Enhanced registration feedback: More nuanced guidance and suggestion for taken usernames

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showUsernameError(username_notify, '[[error:username-taken]]', username);
                 }
 
                 callback();
@@ -178,6 +178,18 @@ define('forum/register', [
     function showError(element, msg) {
         translator.translate(msg, function (msg) {
             element.html(msg);
+            element.parent()
+                .removeClass('register-success')
+                .addClass('register-danger');
+            element.show();
+        });
+        validationError = true;
+    }
+
+    function showUsernameError(element, msg, username) {
+        translator.translate(msg, function (translated_msg) {
+            const final_msg = `${translated_msg}. Maybe try \"${username}suffix\"`
+            element.html(final_msg);
             element.parent()
                 .removeClass('register-success')
                 .addClass('register-danger');


### PR DESCRIPTION
Resolves #1 
Before, the message when a user tries to register an already taken username would just inform them of that fact. I created a function similar to "showError" that takes in a username as an extra argument and displays a more complex message. I provide a suggestion that's similar to the original username by appending a suffix.