### PR TITLE
Updated 'Username taken' error message to suggest username

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -36,7 +36,7 @@
 
 	"invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
 
-	"username-taken": "Username taken",
+	"username-taken": "Username taken. Maybe try %1",
 	"email-taken": "Email taken",
 	"email-nochange": "The email entered is the same as the email already on file.",
 	"email-invited": "Email was already invited",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try %1",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken, "' + username + 'suffix"]]');
                 }
 
                 callback();


### PR DESCRIPTION
Resolves https://github.com/CMU-313/NodeBB-S24-R3/issues/1.
If the username is already in use, suggests alternative username in error message.