### PR TITLE
Add suffix recommender to username registration

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]]' + `. Maybe try "${username}suffix"`);
                 }
 
                 callback();


### PR DESCRIPTION
Adds a message to try a suffix if the username is taken (adds '. Maybe try "[username]suffix"').

resolves #1 