### PR TITLE
Updating username taken error to suggest a new username 

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try ",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]] ' + username + 'suffix');
                 }
 
                 callback();


### PR DESCRIPTION
Fixes #1

Adds alternate username suggestion to the error that is displayed when a user tries to use a username that is already taken. It suggests the username+'suffix'. 