### PR TITLE
feat:suggest new name when username is taken in public/src/client/register.js

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]]. Maybe try ${username}suffix`);
                 }
 
                 callback();


### PR DESCRIPTION
Resolves issue #1 
Suggests a new name in the error message if the current username is taken
public/src/client/register.js
edited function validateUsername