### PR TITLE
Suggest new username if username is already taken when registering

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const msg = '[[error:username-taken]]. Maybe try "' + username.concat("suffix") + '"';
+                    showError(username_notify, msg);
                 }
 
                 callback();


### PR DESCRIPTION
NodeBB should automatically suggest a new username when the chosen username is already in use by appending a suffix string to the user's original choice. For example, if a user selects `test123` and it is taken, NodeBB should suggest `test123suffix`as an alternative.

Resolves https://github.com/CMU-313/NodeBB-S24-R3/issues/1
<img width="1440" alt="Screenshot 2024-09-16 at 11 50 33 AM" src="https://github.com/user-attachments/assets/356328c1-fc52-4136-a0f5-a11845fb9e5d">


