### PR TITLE
Changed error message in error.json and register.js to add suggested username

### DIFF
--- a/public/language/en-x-pirate/error.json
+++ b/public/language/en-x-pirate/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try %1",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken, "${username}suffix"]]');
                 }
 
                 callback();


### PR DESCRIPTION
In error.json, "username-taken" was changed from "Username taken." to "Username taken. Maybe try %1".

In register.js, the error displayed was changed from [[error:username-taken]] to [[error:username-taken, "${username}suffix"]] to support the addition of 'suffix' to the username for a suggested username.

Worked on this with [@paulinezhanghh](https://github.com/paulinezhanghh) in recitation

resolves #1 