### PR TITLE
Add suggested username when username taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]]' + '. Maybe try ' + username + '123?');
                 }
 
                 callback();


### PR DESCRIPTION
Added suggested username (taken username + "123") to the error message that shows up when the username entered is taken.

Resolves #1 