### PR TITLE
Add a suffix to proposed username if taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]]. Maybe try ${username}_1?');
                 }
 
                 callback();


### PR DESCRIPTION
This resolves #1.

If a proposed username is already being used, suggest to the user a new username with a suffix appended.