### PR TITLE
Added suggested username for user registration conflict

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -113,7 +113,7 @@ define('forum/register', [
 
     function validateUsername(username, callback) {
         callback = callback || function () {};
-        console.log("here");
+
         const username_notify = $('#username-notify');
         const userslug = slugify(username);
         if (username.length < ajaxify.data.minimumUsernameLength ||

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -113,7 +113,7 @@ define('forum/register', [
 
     function validateUsername(username, callback) {
         callback = callback || function () {};
-
+        console.log("here");
         const username_notify = $('#username-notify');
         const userslug = slugify(username);
         if (username.length < ajaxify.data.minimumUsernameLength ||
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const nameWithSuffix = username+"suffix";
+                    showError(username_notify, '[[error:username-taken]]'+". Maybe try \""+nameWithSuffix+"\"");
                 }
 
                 callback();


### PR DESCRIPTION
This change added a suggested username to the error message for registering users in register.js.  The suggested username is the provide username concat with the string suffix. 

Resolves #1 