### PR TITLE
Modify error message for username field in Register page

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]]'+ '. Maybe try '+username+'suffix');
                 }
 
                 callback();


### PR DESCRIPTION
When a username already existed, instead of just showing "Username taken" we want to suggest a new username, specifically the username that the user input but add suffix at the end.
resolves #1 