### PR TITLE
add suffix to taken username in public/src/client/register.js

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]] - ${username}-17313`);
                 }
 
                 callback();


### PR DESCRIPTION
Adjusted the error message in `register.js` when a username is taken to propose a new username with a suffix added on. resolves #161 