### PR TITLE
Appending suffix when username taken in public/src/client/register.js

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, '[[error:username-taken]] ' + username + 'suf');
                 }
 
                 callback();


### PR DESCRIPTION
Appended the suffix 'suf' to the user's desired username, and included this is the error message when a username is already taken.

Resolves #1