### PR TITLE
Improved error message when username is taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    const suggestedUsername = username + "suffix"
+                    showError(username_notify, 'Username taken. Maybe try "' + suggestedUsername + '"');
                 }
 
                 callback();


### PR DESCRIPTION
Instead of erroring the message "Username is taken"

The message is now "Username is taken. Maybe try "[username]suffix"