### PR TITLE
Suggest adding suffix when username taken

### DIFF
--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -31,7 +31,7 @@
     "invalid-path": "Invalid path",
     "folder-exists": "Folder exists",
     "invalid-pagination-value": "Invalid pagination value, must be at least %1 and at most %2",
-    "username-taken": "Username taken",
+    "username-taken": "Username taken. Maybe try %1",
     "email-taken": "Email taken",
     "email-nochange": "The email entered is the same as the email already on file.",
     "email-invited": "Email was already invited",

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,8 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, 
+                        `[[error:username-taken, "${suggestion}suffix"]]`);
                 }
 
                 callback();


### PR DESCRIPTION
Linked to #1 
If a user tries to register with a taken username, suggest appending "suffix" to the name.