### PR TITLE
Added new username suggestion with suffix "_123" to the error notification

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -131,7 +131,7 @@ define('forum/register', [
                 if (results.every(obj => obj.status === 'rejected')) {
                     showSuccess(username_notify, successIcon);
                 } else {
-                    showError(username_notify, '[[error:username-taken]]');
+                    showError(username_notify, `[[error:username-taken]], try '${username}_123'`);
                 }
 
                 callback();


### PR DESCRIPTION
Resolves #1 
Updated register.js so that the error notification for the frontend suggests a new username by adding a "_123" suffix. 